### PR TITLE
[Feat] Support slice for reader

### DIFF
--- a/examples/slice_reader.py
+++ b/examples/slice_reader.py
@@ -1,0 +1,25 @@
+import libcachesim as lcs
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+
+URI = "s3://cache-datasets/cache_dataset_oracleGeneral/2007_msr/msr_hm_0.oracleGeneral.zst"
+reader = lcs.TraceReader(
+    trace = URI,
+    trace_type = lcs.TraceType.ORACLE_GENERAL_TRACE,
+    reader_init_params = lcs.ReaderInitParam(ignore_obj_size=False)
+)
+
+for req in reader[:3]:
+    print(req.obj_id, req.obj_size)
+
+for req in reader[1:4]:
+    print(req.obj_id, req.obj_size)
+
+reader.reset()
+read_n_req = 4
+for req in reader:
+    if read_n_req <= 0:
+        break
+    print(req.obj_id, req.obj_size)
+    read_n_req -= 1

--- a/libcachesim/cache.py
+++ b/libcachesim/cache.py
@@ -81,6 +81,9 @@ class CacheBase(ABC):
 
     def get_n_obj(self) -> int:
         return self._cache.get_n_obj()
+    
+    def set_cache_size(self, new_size: int) -> None:
+        self._cache.set_cache_size(new_size)
 
     def print_cache(self) -> str:
         return self._cache.print_cache()

--- a/src/export_cache.cpp
+++ b/src/export_cache.cpp
@@ -352,6 +352,10 @@ void export_cache(py::module& m) {
       .def("get_occupied_byte",
            [](cache_t& self) { return self.get_occupied_byte(&self); })
       .def("get_n_obj", [](cache_t& self) { return self.get_n_obj(&self); })
+      .def(
+          "set_cache_size",
+          [](cache_t& self, uint64_t new_size) { self.cache_size = new_size; },
+          "new_size"_a)
       .def("print_cache", [](cache_t& self) {
         // Capture stdout to return as string
         std::ostringstream captured_output;

--- a/src/export_reader.cpp
+++ b/src/export_reader.cpp
@@ -98,6 +98,13 @@ void export_reader(py::module& m) {
       .value("UNKNOWN_TRACE", trace_type_e::UNKNOWN_TRACE)
       .export_values();
 
+  // Trace format enumeration
+  py::enum_<trace_format_e>(m, "TraceFormat")
+      .value("BINARY_TRACE_FORMAT", trace_format_e::BINARY_TRACE_FORMAT)
+      .value("TXT_TRACE_FORMAT", trace_format_e::TXT_TRACE_FORMAT)
+      .value("INVALID_TRACE_FORMAT", trace_format_e::INVALID_TRACE_FORMAT)
+      .export_values();
+
   py::enum_<read_direction>(m, "ReadDirection")
       .value("READ_FORWARD", read_direction::READ_FORWARD)
       .value("READ_BACKWARD", read_direction::READ_BACKWARD)
@@ -302,11 +309,9 @@ void export_reader(py::module& m) {
       .def(
           "skip_n_req",
           [](reader_t& self, int n) {
-            int ret = skip_n_req(&self, n);
-            if (ret != 0) {
-              throw std::runtime_error("Failed to skip requests");
-            }
-            return ret;
+            int count = skip_n_req(&self, n);
+            // Return the actual number of requests skipped
+            return count;
           },
           "n"_a)
       .def("read_one_req_above",


### PR DESCRIPTION
Example

```python
import libcachesim as lcs
import logging
logging.basicConfig(level=logging.DEBUG)


URI = "s3://cache-datasets/cache_dataset_oracleGeneral/2007_msr/msr_hm_0.oracleGeneral.zst"
reader = lcs.TraceReader(
    trace = URI,
    trace_type = lcs.TraceType.ORACLE_GENERAL_TRACE,
    reader_init_params = lcs.ReaderInitParam(ignore_obj_size=False)
)

for req in reader[:3]:
    print(req.obj_id, req.obj_size)

for req in reader[1:4]:
    print(req.obj_id, req.obj_size)

reader.reset()
read_n_req = 4
for req in reader:
    if read_n_req <= 0:
        break
    print(req.obj_id, req.obj_size)
    read_n_req -= 1
```